### PR TITLE
"DeprecationWarning'" error fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hiven",
   "version": "2.0.11",
   "description": "Hiven.js - TS/JS bot library for Hiven",
-  "main": "dist/index.js",
+  "main": "index.js",
   "scripts": {
     "build": "tsc",
     "dev": "tsc -w",


### PR DESCRIPTION
**Please describe your changes and why you think it should be merged with master:**

Changes in file package.json: "main": "dist/index.js" to  "main": "index.js"

Reason: 
when node.js starts, it throws error:
"DeprecationWarning: Invalid 'main' field in '/app/node_modules/hiven/package.json' of 'dist/index.js'. Please either fix that or report it to the module author"

so I changed it and the error was no longer throwing

My node.js version: v16.10.0

**Status**

- [x] Code changes have been tested with the Hiven API, or there was no code changed

**Semantic versioning classification:**  
- [x] This PR changes an interface in the library [methods or parameters added/changed]
  - [ ] This PR includes breaking changes (removed/renamed methods/paramters)
- [ ] This PR **only** contains non-code modifications, like updating documentation, README, ROADMAP, CHANGELOG, etc.